### PR TITLE
Localization for PT-BR & FR, updated all texts

### DIFF
--- a/billie/Preview Content/en.lproj/Localizable.strings
+++ b/billie/Preview Content/en.lproj/Localizable.strings
@@ -6,5 +6,30 @@
   
 */
 
-"Let me help you! 😃" = "Let me help you! 😃"
-
+"10% Tip" = "10% Tip";
+"Error fetching data" = "Error fetching data";
+"Please enter the price per unit" = "Please enter the price per unit";
+"Success!" = "Success!";
+"Let me help you 😃" = "Let me help you 😃";
+"You can use Billie to scan you table's receipt, edit the itens or values captured by the scan (in case you need to), add up your share of the expenses, and send the payment to the restaurant." = "You can use Billie to scan you table's receipt, edit the itens or values captured by the scan (in case you need to), add up your share of the expenses, and send the payment to the restaurant.";
+"Got it" = "Got it";
+"Scan error" = "Scan error";
+"There was an error scanning your receipt 😟 You can try again framing only its most important parts (the itens and the prices)" = "There was an error scanning your receipt 😟 You can try again framing only its most important parts (the itens and the prices)";
+"Try again" = "Try again";
+"Slide to pay" = "Slide to pay";
+"Scan receipt" = "Scan receipt";
+"Enter manually" = "Enter manually";
+"Cash" = "Cash";
+"This payment method isn't available yet" = "This payment method isn't available yet";
+"Sorry! Our team is working to make this feature available as soon as possible." = "Sorry! Our team is working to make this feature available as soon as possible.";
+"Pay with \(PaymentIndex[selectedIndex])" = "Pay with \(PaymentIndex[selectedIndex])";
+"Edit name" = "Edit name";
+"Edit price" = "Edit price";
+"The scanning was successful! You can edit your receipt below if you want to" = "The scanning was successful! You can edit your receipt below if you want to";
+"Delete" = "Delete";
+"Edit" = "Edit";
+"Here is your receipt" = "Here is your receipt";
+"Please edit this item" = "Please edit this item";
+"Payment methods" = "Payment methods";
+"Add payment method" = "Add payment method";
+"Pay now" = "Pay now";

--- a/billie/Preview Content/fr.lproj/Localizable.strings
+++ b/billie/Preview Content/fr.lproj/Localizable.strings
@@ -6,5 +6,30 @@
   
 */
 
-"Let me help you! 😃" = "Laisse-moi t'aider ! 😃"
-
+"10% Tip" = "10% du pourboire";
+"Error fetching data" = "Une erreur s'est produite pendant l'extraction des données";
+"Please enter the price per unit" = "Saisie le prix unitaire, s'il te plait";
+"Success!" = "Succès !";
+"Let me help you! 😃" = "Laisse-moi t'aider ! 😃";
+"You can use Billie to scan you table's receipt, edit the itens or values captured by the scan (in case you need to), add up your share of the expenses, and send the payment to the restaurant." = "Tu peux utiliser Billie pour scanner l'addition dans un bar ou restaurant, éditer les informations ou les prix (en cas de besoin), calculer ta part des dépenses, et envoyer le payment au restaurant.";
+"Got it" = "Ok";
+"Scan error" = "Erreur de numérisation";
+"There was an error scanning your receipt 😟 You can try again framing only its most important parts (the itens and the prices)" = "Il y a eu un erreur pendant la numérisation de la facture 😟 Tu peux réessayer en encadrant juste les informations les plus importantes (les articles et les prix)";
+"Try again" = "Réessayer";
+"Slide to pay" = "Glisser pour payer";
+"Scan receipt" = "Scanner l'addition";
+"Enter manually" = "Saisir manuellement";
+"Cash" = "Espèces";
+"This payment method isn't available yet" = "Cette méthode de payment n'est pas encore disponible";
+"Sorry! Our team is working to make this feature available as soon as possible." = "Désolé! Notre équipe travaille maintenant pour mettre cette fonctionalité à disposition aussitôt que possible";
+"Pay with \(PaymentIndex[selectedIndex])" = "Payer avec \(PaymentIndex[selectedIndex])";
+"Edit name" = "Éditer le nom";
+"Edit price" = "Éditer le prix";
+"The scanning was successful! You can edit your receipt below if you want to" = "Le scanner a bien marché ! Tu peux aussi éditer la facture en bas si tu veux";
+"Delete" = "Effacer";
+"Edit" = "Éditer";
+"Here is your receipt" = "Voici la facture";
+"Please edit this item" = "Édite cet article, s'il te plait";
+"Payment methods" = "Méthodes de payment";
+"Add payment method" = "Ajouter une méthode de payment";
+"Pay now" = "Payer maintenant";

--- a/billie/Preview Content/pt-BR.lproj/Localizable.strings
+++ b/billie/Preview Content/pt-BR.lproj/Localizable.strings
@@ -6,5 +6,30 @@
   
 */
 
-"Let me help you! 😃" = "Deixa eu te ajudar! 😃"
-
+"10% Tip" = "10% da gorgeta";
+"Error fetching data" = "Erro ao capturar os dados";
+"Please enter the price per unit" = "Por favor, digite o preço por unidade";
+"Success!" = "Sucesso!";
+"Let me help you 😃" = "Deixa eu te ajudar 😃";
+"You can use Billie to scan you table's receipt, edit the itens or values captured by the scan (in case you need to), add up your share of the expenses, and send the payment to the restaurant." = "Você pode usar o Billie para escanear a nota fiscal da sua mesa, editar os itens ou valores escaneados (caso você precise), somar sua parte dos gastos, e enviar o pagamento para o restaurante.";
+"Got it" = "Entendi";
+"Scan error" = "Erro ao escanear";
+"There was an error scanning your receipt 😟 You can try again framing only its most important parts (the itens and the prices)" = "Aconteceu um erro ao escanear sua nota. Você pode tentar de novo enquadrando apenas a parte mais importante (os itens e preços)";
+"Try again" = "Tentar de novo";
+"Slide to pay" = "Deslize para pagar";
+"Scan receipt" = "Escanear a nota";
+"Enter manually" = "Digitar manualmente";
+"Cash" = "Dinheiro";
+"This payment method isn't available yet" = "Este método de pagamento ainda não está disponível";
+"Sorry! Our team is working to make this feature available as soon as possible." = "Desculpe, nosso time está trabalhando para disponibilizar esta funcionalidade o quanto antes.";
+"Pay with \(PaymentIndex[selectedIndex])" = "Pagar com \(PaymentIndex[selectedIndex])";
+"Edit name" = "Editar o nome";
+"Edit price" = "Editar o preço";
+"The scanning was successful! You can edit your receipt below if you want to" = "O scanner foi bem sucedido! Você pode editar sua conta abaixo se você quiser";
+"Delete" = "Deletar";
+"Edit" = "Editar";
+"Here is your receipt" = "Aqui está sua conta";
+"Please edit this item" = "Por favor, edite este item";
+"Payment methods" = "Formas de pagamento";
+"Add payment method" = "Adicionar forma de pagamento";
+"Pay now" = "Pagar agora";

--- a/billie/View/BillListRow.swift
+++ b/billie/View/BillListRow.swift
@@ -55,7 +55,7 @@ struct billListRow: View {
 
                 HStack{
                     if item.isEditing {
-                        TextField("Edite o valor unitário", value: $item.unitPrice, formatter: formatter)
+                        TextField("Edit price", value: $item.unitPrice, formatter: formatter)
                             .foregroundColor(item.unitPrice == 0.0 ? Color.red : Color.primary)
                             .keyboardType(.decimalPad)
                             .textFieldStyle(.roundedBorder)

--- a/billie/View/BillListView.swift
+++ b/billie/View/BillListView.swift
@@ -36,7 +36,7 @@ struct BillListView: View {
                     Section{
                         
                     } header: {
-                        Text("successfully scanned, you can modify your tab below")
+                        Text("The scanning was successful! You can edit your receipt below if you want to")
                             .font(.subheadline)
                             .listRowBackground(Color(.clear))
                             .listRowSeparator(.hidden)
@@ -76,7 +76,7 @@ struct BillListView: View {
                 }
                 .listStyle(.grouped)
                 .navigationBarTitleDisplayMode(.inline)
-                .navigationTitle("Resume Tabs")
+                .navigationTitle("Here is your receipt")
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {

--- a/billie/View/CheckScreen/CheckView.swift
+++ b/billie/View/CheckScreen/CheckView.swift
@@ -36,7 +36,7 @@ struct CheckView: View {
         .onDisappear{
             itemData.removeAll()
         }
-        .navigationTitle("Resume tabs")
+        .navigationTitle("Here is your receipt")
         .navigationDestination(isPresented: $shouldPop) {
             LottieSucessView()
                 .onDisappear {

--- a/billie/View/CheckoutView.swift
+++ b/billie/View/CheckoutView.swift
@@ -19,16 +19,16 @@ struct CheckoutView: View {
     var body: some View {
         VStack{
             Spacer(minLength: 20)
-            Section(header: Text("Formas de pagamento")
+            Section(header: Text("Payment methods")
                 .bold()
                 .font(.title3)
             ){
                 
                 List{
                     Label ( "Pix", image: "IconPix")
-                    Label ( "Dinheiro", image: "IconMoney")
+                    Label ( "Cash", image: "IconMoney")
                     Label ( "Apple pay", image: "IconApplePay")
-                    Label ( "Add forma de pagamento", systemImage: "plus")
+                    Label ( "Add payment method", systemImage: "plus")
                     
                 }
                 Spacer(minLength: 20)
@@ -38,7 +38,7 @@ struct CheckoutView: View {
                 Button {
                     // nada
                 } label: {
-                    Text("Fazer pagamento")
+                    Text("Pay now")
                         .padding()
                         .font(.title2)
                         .foregroundColor(.white)

--- a/billie/View/HomeScreenView.swift
+++ b/billie/View/HomeScreenView.swift
@@ -43,9 +43,9 @@ struct HomeScreenView: View {
                             .font(Font.body)
                             .padding(.all, 10)
                     }.alert(isPresented: $alertHelpButton) {
-                        Alert(title: Text("Let me help you! 😃"),
-                              message: Text("You can use Billie to scan you table's receipt, edit the itens or values, and send the payment to the restaurant on your phone. All in one simple app!"),
-                              dismissButton: .default(Text("Ok, got it!")))
+                        Alert(title: Text("Let me help you 😃"),
+                              message: Text("You can use Billie to scan you table's receipt, edit the itens or values captured by the scan (in case you need to), add up your share of the expenses, and send the payment to the restaurant."),
+                              dismissButton: .default(Text("Got it")))
                     }
                 }
             }
@@ -57,7 +57,7 @@ struct HomeScreenView: View {
             }
             .alert(isPresented: $alertError){
                 Alert(title: Text("Scan error"),
-                      message: Text("There was an error scanning your receipt, please try to frame only its important (the itens and the prices)"),
+                      message: Text("There was an error scanning your receipt 😟 You can try again framing only its most important parts (the itens and the prices)"),
                       dismissButton: .default(Text("Try again")))
             }
         }

--- a/billie/View/List/ItemBillCell.swift
+++ b/billie/View/List/ItemBillCell.swift
@@ -42,7 +42,7 @@ struct ItemBillCell: View {
                 HStack(alignment: .bottom) {
                     
                     if itemModel.isEditing {
-                        TextField("Please enter price per unit", value: $itemModel.unitPrice, formatter: itemModel.formatter)
+                        TextField("Please enter the price per unit", value: $itemModel.unitPrice, formatter: itemModel.formatter)
                             .textFieldStyle(.roundedBorder)
                             .foregroundColor(itemModel.invalidDoubleValue(value: itemModel.unitPrice))
                             .keyboardType(.decimalPad)

--- a/billie/View/List/ItemListView.swift
+++ b/billie/View/List/ItemListView.swift
@@ -45,7 +45,7 @@ struct ItemListView: View {
     }
     
     var header: some View {
-        Text("SUCCESS")
+        Text("Success!")
             .font(.subheadline)
             .foregroundColor(.secondary)
     }

--- a/billie/View/PaymentView.swift
+++ b/billie/View/PaymentView.swift
@@ -33,9 +33,9 @@ struct PaymentView: View {
                             selectedIndex > 0 ? alertButton.toggle(): nil
                         })
                         .alert(isPresented: $alertButton) {
-                            Alert(title: Text("Payment method not available"),
-                                  message: Text("We're sorry to inform this method is not avaible at the moment!"),
-                                  dismissButton: .default(Text("Ok, got it!")))
+                            Alert(title: Text("This payment method isn't available yet"),
+                                  message: Text("Sorry! Our team is working to make this feature available as soon as possible."),
+                                  dismissButton: .default(Text("Ok")))
                         }
                     
                 }

--- a/billie/billieApp.swift
+++ b/billie/billieApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// Below, ladies and gentleman, the best mockup names ever invented XD (by Otávio, of course)
 @main
 struct billieApp: App {
     @State var items: [TabItem] = [


### PR DESCRIPTION
Updated all texts in the app according to Apple guidelines (respecting the style and tone of the app). Finished localization for Brazilian Portuguese and French, but there are still a couple of bugs: the buttons "Slide to pay" and "Pay with cash" never get translated. 